### PR TITLE
bug fix: hadoop/list 链接错误

### DIFF
--- a/src/components/hdfs.vue
+++ b/src/components/hdfs.vue
@@ -29,7 +29,7 @@
 		name: 'hdfs',
 		data() {
 			return {
-				hdfs: config.HDFS_BACKEND+"hadoop/list",
+				hdfs: config.HDFS_BACKEND+"/hadoop/list",
 			}
 		},
 	}


### PR DESCRIPTION
hadoop/list 链接前少了一个斜杠